### PR TITLE
Add extension to skip pointer for optional fields

### DIFF
--- a/pkg/codegen/extension.go
+++ b/pkg/codegen/extension.go
@@ -8,8 +8,9 @@ import (
 )
 
 const (
-	extPropGoType    = "x-go-type"
-	extPropOmitEmpty = "x-omitempty"
+	extPropGoType                    = "x-go-type"
+	extPropOmitEmpty                 = "x-omitempty"
+	extPropGoTypeSkipOptionalPointer = "x-go-type-skip-optional-pointer"
 )
 
 func extTypeName(extPropValue interface{}) (string, error) {
@@ -23,6 +24,19 @@ func extTypeName(extPropValue interface{}) (string, error) {
 	}
 
 	return name, nil
+}
+
+func extParsePropGoTypeSkipOptionalPointer(extPropValue interface{}) (bool, error) {
+	raw, ok := extPropValue.(json.RawMessage)
+	if !ok {
+		return false, fmt.Errorf("failed to convert type: %T", extPropValue)
+	}
+
+	var goTypeSkipOptionalPointer bool
+	if err := json.Unmarshal(raw, &goTypeSkipOptionalPointer); err != nil {
+		return false, errors.Wrap(err, "failed to unmarshal json")
+	}
+	return goTypeSkipOptionalPointer, nil
 }
 
 func extParseOmitEmpty(extPropValue interface{}) (bool, error) {


### PR DESCRIPTION
useful for treating empty go value instead of nil pointer when serializing to json:

```yaml
components:
  schemas:
    MyType:
      type: object
      properties:
        a:
          type: string

    MyType2:
      type: object
      properties:
        a:
          type: string
          x-go-type-skip-optional-pointer: true
```

will generate these two go types

```golang
type MyType struct {
    A *string `json:"omitempty"`
}

type MyType2 struct {
    A string `json:"omitempty"`
}
```

which is very useful for optional enum types:

```yaml
components:
  schemas:
    Code:
      x-go-type-skip-optional-pointer: true
      type: string
      enum:
        - "empty"
        - "invalid"
        - "too-short"
        - "too-long"
        - "too-many"
        - "too-few"
        
    Error:
      type: object
      properties:
        code:
          x-go-type-skip-optional-pointer: true
          $ref: "#/components/schemas/Code"
 ```

generates

```go
const (
    CodeEmpty Code = "empty"
    ...
    ...
)
type Code string

type Error struct {
    Code Code `json:"code,omitempty"`
}

// will serialize to {}
err1 := Error{}

// will serialize to {"code":"empty"}
err2 := Error{ Code: CodeEmpty }

// without skip optional extension, this would be required
var empty = CodeEmpty
err3 := Error{ Code: &empty }

// it also simplifies comparison since nil guards are not needed
if err2.Code == "xyz" { }
if err3.Code != nil && *err.Code == "xyz" { }
if common.StrP(err3.Code) == "xyz" { } // okay but first alt is still better
```